### PR TITLE
Fix undefined `_this` reference error when using v-model on select, radio and checkbox.

### DIFF
--- a/src/babel-sugar-v-model-v1.1.2-patch.js
+++ b/src/babel-sugar-v-model-v1.1.2-patch.js
@@ -33,7 +33,7 @@ module.exports = ({ types: t }) => {
             path.traverse({
               JSXAttribute(path) {
                 const n = path.get("name");
-                const isInputOrModel = n.node.name === "on-input" || n.node.name === "model";
+                const isInputOrModel = n.node.name === "on-input" || n.node.name === "on-change" || n.node.name === "model";
                 if (!isInputOrModel) return;
                 path.traverse({
                   MemberExpression(path) {


### PR DESCRIPTION
Currently select, radio and checkbox controls give undefined `_this` reference error when using them in jsx block with composition api. Since these element types use `onChange` event instead of `onInput` to change the state of the binded target, the patch should also modify `_this.$set` usages to `Vue.set` in these handlers also.