### PR TITLE
Add fix for breaking createElement name change

### DIFF
--- a/src/babel-sugar-inject-h.js
+++ b/src/babel-sugar-inject-h.js
@@ -42,7 +42,7 @@ const autoImportH = (t, path) => {
         const vcaImportNodes = importNodes.filter(p => p.source.value === importSource);
         const hasH = vcaImportNodes.some(p => (
             p.specifiers.some(s => (
-                t.isImportSpecifier(s) && s.imported.name === 'createElement' && s.local.name === 'h'
+                t.isImportSpecifier(s) && s.imported.name === 'h' && s.local.name === 'h'
             ))
         ));
         if (!hasH) {

--- a/src/babel-sugar-inject-h.js
+++ b/src/babel-sugar-inject-h.js
@@ -46,7 +46,7 @@ const autoImportH = (t, path) => {
             ))
         ));
         if (!hasH) {
-            const vcaImportSpecifier = t.importSpecifier(t.identifier('h'), t.identifier('createElement'));
+            const vcaImportSpecifier = t.importSpecifier(t.identifier('h'), t.identifier('h'));
             if (vcaImportNodes.length > 0) {
                 vcaImportNodes[0].specifiers.push(vcaImportSpecifier);
             } else {


### PR DESCRIPTION
The first VCA beta was released yesterday, and it included a breaking change renaming `createElement` to `h`

https://github.com/vuejs/composition-api/releases/tag/v1.0.0-beta.1